### PR TITLE
fix: destructive foreground color was wrong

### DIFF
--- a/__tests__/modules/pubblica-web/pubblica-web-api-client.test.ts
+++ b/__tests__/modules/pubblica-web/pubblica-web-api-client.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import { PubblicaWebApi } from "@/modules/pubblica-web/pubblica-web-api-client";
-import * as fs from "node:fs";
 import { serverEnv } from "@/env/server-env";
 
 describe("pubblica-web-api", () => {
@@ -26,5 +25,27 @@ describe("pubblica-web-api", () => {
   //   const res = await client.fetchPayslips(date);
   //   // write contents to file
   //   fs.writeFileSync(res.name, res.bytes);
+  // });
+  //
+  // test("it fetches all payslips for a given employee", async () => {
+  //   const id = 125;
+  //   const employees = await kEmployeesServer.listAll();
+  //   if (isFailure(employees)) {
+  //     return;
+  //   }
+  //   await client.authenticate();
+  //   for (const employee of employees) {
+  //     // Mark & Dan are not employee,
+  //     const email = employee.email ?? "";
+  //     if (email === "marco@kuama.it" || email === "daniele@kuama.net") {
+  //       continue;
+  //     }
+  //
+  //     const res = await client.fetchPayslipsForEmployee(
+  //       employee.fullName?.toUpperCase() ?? "",
+  //     );
+  //
+  //     expect(res.length).not.toBe(0);
+  //   }
   // });
 });

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -107,6 +107,7 @@ export const kPayrolls = pgTable("k_payrolls", {
   net: real().notNull(),
   gross: real().notNull(),
   date: date().notNull(),
+  payrollNumber: integer().notNull().default(0), // 1, 2, 3...13 (or 14 if we move to commercial sector)
   url: varchar({ length: 1500 }).notNull(),
   dipendentiInCloudPayrollId: varchar({ length: 256 }).unique(),
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,7 +127,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.97 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.87 0 0);
@@ -167,7 +167,7 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.269 0 0);
   --input: oklch(0.269 0 0);
   --ring: oklch(0.439 0 0);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
   {
     variants: {
       variant: {

--- a/src/modules/k-clients/actions/k-client-get-overall-invoiced-amount.ts
+++ b/src/modules/k-clients/actions/k-client-get-overall-invoiced-amount.ts
@@ -3,8 +3,13 @@ import { kInvoices } from "@/drizzle/schema";
 import { sum } from "drizzle-orm";
 import { firstOrThrow } from "@/utils/array-utils";
 import { handleServerErrors } from "@/utils/server-action-utils";
+import { auth } from "@/modules/auth/auth";
 
 async function kClientGetOverallInvoicedAmount() {
+  const session = await auth();
+  if (!session || !session.user?.isAdmin) {
+    throw new Error("Only admin is allowed to invoke this action");
+  }
   const amounts = await db
     .select({ value: sum(kInvoices.amountGross) })
     .from(kInvoices);

--- a/src/modules/k-clients/actions/k-client-get-total-invoiced-amount.ts
+++ b/src/modules/k-clients/actions/k-client-get-total-invoiced-amount.ts
@@ -4,12 +4,18 @@ import { eq, sum } from "drizzle-orm";
 import { inArray } from "drizzle-orm/sql/expressions/conditions";
 import { firstOrThrow } from "@/utils/array-utils";
 import { handleServerErrors } from "@/utils/server-action-utils";
+import { auth } from "@/modules/auth/auth";
 
 async function kClientGetTotalInvoicedAmount({
   clientId,
 }: {
   clientId: number;
 }) {
+  const session = await auth();
+  if (!session || !session.user?.isAdmin) {
+    throw new Error("Only admin is allowed to invoke this action");
+  }
+
   const clientWithVatsRecords = await db.query.kClients.findMany({
     with: {
       kClientsVats: {

--- a/src/modules/k-clients/components/k-client-card.tsx
+++ b/src/modules/k-clients/components/k-client-card.tsx
@@ -42,11 +42,11 @@ export const KClientCard = async ({ client, index = 0 }: Props) => {
           </div>
           <p>{client.projectsCount} projects</p>
           <p>{client.employeesWorkingForClientCount} employees involved</p>
-          {session?.user?.isAdmin && (
-            <Suspense>
-              <KClientInvoicedAmount clientId={client.id} />
-            </Suspense>
-          )}
+          {/*{session?.user?.isAdmin && (*/}
+          {/*  <Suspense>*/}
+          {/*    <KClientInvoicedAmount clientId={client.id} />*/}
+          {/*  </Suspense>*/}
+          {/*)}*/}
         </div>
         <HiArrowSmRight className="pointer-events-none absolute right-0 opacity-0 text-2xl text-gray-300 group-hover:opacity-100 group-hover:right-4 transition-all" />
       </div>

--- a/src/modules/k-clients/components/k-clients-list.tsx
+++ b/src/modules/k-clients/components/k-clients-list.tsx
@@ -16,9 +16,9 @@ export default async function KClientsList() {
   return (
     <div className="pt-16">
       <Title>Clients</Title>
-      <p className="font-bold">
-        &euro; {new Intl.NumberFormat().format(totalInvoicedAmount)}
-      </p>
+      {/*<p className="font-bold">*/}
+      {/*  &euro; {new Intl.NumberFormat().format(totalInvoicedAmount)}*/}
+      {/*</p>*/}
 
       <div className="grid gap-12 sm:grid-cols-1 md:grid-cols-3 py-8 items-center">
         {clients.map((client, index) => (


### PR DESCRIPTION
fix: ensure admin only for invoices
feat: read all employee payslips by employee name from pubblicaweb
chore: add payroll number to schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced functionality to retrieve payslips for employees.
  - Enforced admin authentication for accessing invoiced data.

- **Style**
  - Updated the destructive action color palette for improved visibility.
  - Enhanced button interactivity with a pointer cursor.

- **Refactor**
  - Streamlined the client interface by removing the direct display of total invoiced amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->